### PR TITLE
month naming convention fix

### DIFF
--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -179,58 +179,9 @@ export const getLocaleMonth = (date: Date, locale: string) => {
     bottomValue[0],
     bottomValue[0].toLocaleUpperCase()
   );
-  switch(bottomValue){
-    case "January":
-      bottomValue = "01";
-      break;
-
-    case "February":
-      bottomValue = "02";
-      break;
-    
-    case "March":
-      bottomValue = "03";
-      break;
-        
-    case "April":
-      bottomValue = "04";
-      break;
-
-    case "May":
-      bottomValue = "05";
-      break;
-
-    case "June":
-      bottomValue = "06";
-      break;
-    
-    case "July":
-      bottomValue = "07";
-      break;
-
-    case "August":
-      bottomValue = "08";
-      break;
-    
-    case "September":
-      bottomValue = "09";
-      break;
-        
-    case "October":
-      bottomValue = "10";
-      break;
-
-    case "November":
-      bottomValue = "11";
-      break;
-
-    case "December":
-      bottomValue = "12";
-      break;
-      
-    default :
-      break; 
-  }
+  const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  let monthNumber : number =monthNames.indexOf(bottomValue) + 1;
+  bottomValue = monthNumber < 10 ? '0' + monthNumber.toString() : monthNumber.toString();
   return bottomValue;
 };
 

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -180,7 +180,7 @@ export const getLocaleMonth = (date: Date, locale: string) => {
     bottomValue[0].toLocaleUpperCase()
   );
   const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-  let monthNumber : number =monthNames.indexOf(bottomValue) + 1;
+  let monthNumber : number = monthNames.indexOf(bottomValue) + 1;
   bottomValue = monthNumber < 10 ? '0' + monthNumber.toString() : monthNumber.toString();
   return bottomValue;
 };

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -179,6 +179,58 @@ export const getLocaleMonth = (date: Date, locale: string) => {
     bottomValue[0],
     bottomValue[0].toLocaleUpperCase()
   );
+  switch(bottomValue){
+    case "January":
+      bottomValue = "01";
+      break;
+
+    case "February":
+      bottomValue = "02";
+      break;
+    
+    case "March":
+      bottomValue = "03";
+      break;
+        
+    case "April":
+      bottomValue = "04";
+      break;
+
+    case "May":
+      bottomValue = "05";
+      break;
+
+    case "June":
+      bottomValue = "06";
+      break;
+    
+    case "July":
+      bottomValue = "07";
+      break;
+
+    case "August":
+      bottomValue = "08";
+      break;
+    
+    case "September":
+      bottomValue = "09";
+      break;
+        
+    case "October":
+      bottomValue = "10";
+      break;
+
+    case "November":
+      bottomValue = "11";
+      break;
+
+    case "December":
+      bottomValue = "12";
+      break;
+      
+    default :
+      break; 
+  }
   return bottomValue;
 };
 


### PR DESCRIPTION
before months were represented by their actual name but now they are being represented by their month number instead of the month name.